### PR TITLE
fix: match PiliPlus IPA metadata

### DIFF
--- a/all-apps.json
+++ b/all-apps.json
@@ -420,7 +420,7 @@
     },
     {
       "name": "PiliPlus",
-      "bundleIdentifier": "com.example.PiliPlus",
+      "bundleIdentifier": "com.example.piliplus",
       "developerName": "bggRGjQaUbCoE",
       "subtitle": "使用Flutter开发的BiliBili第三方客户端",
       "localizedDescription": "使用Flutter开发的BiliBili第三方客户端",
@@ -704,7 +704,7 @@
       "url": "https://github.com/CyrilPeng/Venera-Next/releases/tag/v1.15.0"
     },
     {
-      "appID": "com.example.PiliPlus",
+      "appID": "com.example.piliplus",
       "title": "PiliPlus 2.1.2.3 · 30 Aug 2026",
       "identifier": "PiliPlus-release-2.1.2.3",
       "caption": "PiliPlus 2.1.2.3 is available.",

--- a/all-apps.json
+++ b/all-apps.json
@@ -21,11 +21,11 @@
       "tintColor": "#FF375F",
       "versions": [
         {
-          "version": "0.8.4",
-          "date": "2026-07-03",
-          "localizedDescription": "- Fixes for iOS 27: fixed settings pages freezing the app, along with other minor visual issues.\r\n- Improved backup restore time: restores should now take seconds instead of minutes. (@Amqx)\r\n- Failed download page retrying: less chance of missing pages in downloaded chapters from sources with aggressive rate limits. (@pxseu)\r\n- New chapter notifications (experimental): when Aidoku refreshes in the background, notification(s) of new chapters should be sent if enabled. (@Zareix)\r\n- Various other bug fixes and small features: see [the website](<https://aidoku.app/release-notes/>) for a more complete list.",
-          "downloadURL": "https://github.com/Aidoku/Aidoku/releases/download/v0.8.4/Aidoku.ipa",
-          "size": 10136987,
+          "version": "0.9",
+          "date": "2026-09-03",
+          "localizedDescription": "- OCR dictionary support (iOS 18+): import Yomitan-compatible dictionaries in the app and look up words while reading.\r\n- Suwayomi built-in source: read and track from a Suwayomi instance, just like Komga and Kavita.\r\n- Auto scroll for webtoon reader: enable and press the play button to scroll without touching your device.\r\n- Fixed CloudFlare handling: CloudFlare issues that caused external sources to break should be resolved.\r\n- Overall performance improvements: the library loads much faster (@Amqx), and the webtoon reader was improved.\r\n- Source stability fixes and disable option: the issue where sources were causing the app to crash should not happen again, and now you can even disable a source that is broken until it receives an update.\r\n- Many more things: see [the website](https://aidoku.app/release-notes/) for a more complete list.",
+          "downloadURL": "https://github.com/Aidoku/Aidoku/releases/download/v0.9/Aidoku.ipa",
+          "size": 11864382,
           "minOSVersion": "15.0"
         }
       ]
@@ -143,11 +143,11 @@
       "tintColor": "#3CAEFF",
       "versions": [
         {
-          "version": "nightly-20260902",
-          "date": "2026-09-02",
-          "localizedDescription": "Automated nightly build for community testing (unsigned).\n\nEvery download is named `ARMSX2-nightly-DATE-COMMIT-PLATFORM`, so builds\nfrom different nights stay distinguishable after you have downloaded them.\n\n- macOS arm64: macOS-arm64.tar.xz\n- Linux arm64: Linux-arm64-4K-pages.AppImage on most distros, or the 16K one on Asahi Linux and other Apple Silicon kernels (run getconf PAGESIZE if unsure)\n- Windows arm64: Windows-arm64.zip\n- RetroArch on Linux arm64: Linux-arm64-libretro-core.tar.zst, a 4K-page build\n- Bare-display kmsdrm handhelds: Linux-arm64-SDL-handheld.tar.zst, a 4K-page build (Rocknix and Batocera run compositors, so use the Qt AppImage there instead)\n- Android: Android-arm64.apk, sideload it\n- iOS: iOS-arm64.ipa, unsigned, sideload it\n\n## What's new\n- VU div unit: gate the console ceiling on the clamp mode\n\nFull changelog: https://github.com/ARMSX2/ARMSX2/compare/nightly-20260901...82b3e3ece4afa627e64d0cc01bc175d06029d2d8",
-          "downloadURL": "https://github.com/ARMSX2/ARMSX2/releases/download/nightly-20260902/ARMSX2-nightly-20260902-82b3e3ece4-iOS-arm64.ipa",
-          "size": 26744122,
+          "version": "nightly-20260904",
+          "date": "2026-09-04",
+          "localizedDescription": "Automated nightly build for community testing (unsigned).\n\nEvery download is named `ARMSX2-nightly-DATE-COMMIT-PLATFORM`, so builds\nfrom different nights stay distinguishable after you have downloaded them.\n\n- macOS arm64: macOS-arm64.tar.xz\n- Linux arm64: Linux-arm64-4K-pages.AppImage on most distros, or the 16K one on Asahi Linux and other Apple Silicon kernels (run getconf PAGESIZE if unsure)\n- Windows arm64: Windows-arm64.zip\n- RetroArch on Linux arm64: Linux-arm64-libretro-core.tar.zst, a 4K-page build\n- Bare-display kmsdrm handhelds: Linux-arm64-SDL-handheld.tar.zst, a 4K-page build (Rocknix and Batocera run compositors, so use the Qt AppImage there instead)\n- Android: Android-arm64.apk, sideload it\n- iOS: iOS-arm64.ipa, unsigned, sideload it\n\n## What's new\n- Pad: bring over the ARMSX3 controller work\n- Pad: let the user choose the rumble fallback for motorless pads (#646)\n- Quick loading: drop each extracted file from the page cache\n- Affinity: Sustained Performance wins over Performance Cores\n\nFull changelog: https://github.com/ARMSX2/ARMSX2/compare/nightly-20260903...aa2a43fffc951d65807600edfc2ff85250677714",
+          "downloadURL": "https://github.com/ARMSX2/ARMSX2/releases/download/nightly-20260904/ARMSX2-nightly-20260904-aa2a43fffc-iOS-arm64.ipa",
+          "size": 26743091,
           "minOSVersion": "17.0"
         }
       ]
@@ -314,11 +314,11 @@
       "tintColor": "#F0D060",
       "versions": [
         {
-          "version": "0.3.14",
-          "date": "2026-08-29",
-          "localizedDescription": "### Added / 新增\n\n- **iOS + macOS**: a retro vinyl record-player now-playing mode (黑胶模式) — programmatic vinyl + tonearm with swipe-to-switch. Opt in from Settings (the default stays 沉浸模式). Thanks @MikeChongCan (#55).\n- **iOS + macOS**：新增黑胶唱片播放页模式（黑胶模式）——矢量唱片 + 唱臂，可滑动切换。默认仍是沉浸模式，可在设置中选择。感谢 @MikeChongCan（#55）。\n- **macOS**: a \"桌面歌词水平居中\" toggle that locks the floating lyric capsule to the horizontal centre of the screen (vertical drag still works). (#48)\n- **macOS**：新增「桌面歌词水平居中」开关，可把悬浮歌词锁定在屏幕水平中央（仍可上下拖动）。（#48）\n\n### Fixed / 修复\n\n- **macOS**: the desktop-lyrics button in the player bar now reflects its on/off state — it read the setting directly and never re-rendered when toggled. (#48)\n- **macOS**：播放条上的桌面歌词按钮现在会正确反映开/关状态——之前直接读取设置、切换后不重绘，颜色卡住。（#48）",
-          "downloadURL": "https://github.com/missuo/kumone/releases/download/v0.3.14/Kumone-iOS-0.3.14.ipa",
-          "size": 7137029,
+          "version": "0.3.16",
+          "date": "2026-09-04",
+          "localizedDescription": "### Added / 新增\n\n- **iOS**: CarPlay Now Playing gains a working Up Next button — tapping it pushes the live playback queue (current track pinned on top, up to 300 upcoming rows), and picking a row jumps straight to that track. Outside FM mode the button row also gains 随机 and 循环 controls whose icons track `shuffleEnabled` / `repeatMode`, and the album-artist button opens the current track's album (falling back to its first artist for cloud-disk tracks with no album). Thanks @MikeChongCan (#54).\n- **iOS**：CarPlay Now Playing 的「播放队列」按钮现在可用——点击弹出实时播放队列（当前曲目置顶，最多 300 条待播），点任意一行直接跳转播放。非 FM 模式下按钮区新增 随机 / 循环 控件，图标跟随 `shuffleEnabled` 与 `repeatMode` 变化；专辑歌手按钮可跳转当前曲目的专辑（云盘歌曲等无专辑信息时回退到第一位歌手）。感谢 @MikeChongCan（#54）。\n- **Build**: `make configure` / `make configure-carplay` select which capabilities the iOS build ships with, plus `make build` / `test` / `app` / `project` wrappers. Run `make` for the list. (#54)\n- **Build**：新增 `make configure` / `make configure-carplay` 切换 iOS 构建包含的能力，另有 `make build` / `test` / `app` / `project` 等封装。执行 `make` 查看全部目标。（#54）\n\n### Changed / 变更\n\n- **iOS**: CarPlay is now excluded from the default build entirely, not just left unsigned — `UISupportsCarPlay` and the `CPTemplateApplicationSceneSessionRoleApplication` scene declaration have moved out of `ios/Config/Info.plist` and are injected, together with the `com.apple.developer.carplay-audio` entitlement, only by `make configure-carplay`. The overlay is written to untracked files and never touches the Xcode project, so enabling CarPlay leaves the working tree clean. Replaces the previous \"uncomment `KumoneIOS.entitlements.example` by hand\" flow. (#54)\n- **iOS**：CarPlay 现在从默认构建中完全移除，而不只是不签名——`UISupportsCarPlay` 与 `CPTemplateApplicationSceneSessionRoleApplication` scene 声明已移出 `ios/Config/Info.plist`，与 `com.apple.developer.carplay-audio` entitlement 一起，仅由 `make configure-carplay` 注入。覆盖文件均不纳入 git 且完全不改动 Xcode 工程，开启 CarPlay 后工作区依然干净。取代原先手动取消注释 `KumoneIOS.entitlements.example` 的流程。（#54）\n\n### Fixed / 修复\n\n- **iOS**: the in-app updater now saves the downloaded IPA into the app's Documents folder — findable in the Files app under On My iPhone ▸ Kumone (the app now enables file sharing) — and opens a share sheet so it can be saved or handed straight to a signing tool (全能签 / ESign / AltStore …), instead of only offering an export dialog that left users unable to locate the file. (#73, #50)\n- **iOS**：应用内更新现在会把下载的 IPA 保存到 App 的 Documents 目录——可在「文件」App ▸ 我的 iPhone ▸ Kumone 里找到（已开启文件共享）——并弹出分享面板，可保存或直接导入签名工具（全能签 / ESign / AltStore 等），不再是之前那种让人找不到文件的导出弹窗。（#73，#50）",
+          "downloadURL": "https://github.com/missuo/kumone/releases/download/v0.3.16/Kumone-iOS-0.3.16.ipa",
+          "size": 7245579,
           "minOSVersion": "16.0"
         }
       ]
@@ -362,11 +362,11 @@
       "tintColor": "#EF4444",
       "versions": [
         {
-          "version": "0.9.1",
-          "date": "2026-09-01",
-          "localizedDescription": "## What's Changed\r\n* Fix cache collision via chapter hash in filename by @NBA2K1 in https://github.com/kodjodevf/mangayomi/pull/967\r\n* fix(mihon-service): update genre parsing to handle string input\r\n* refactor(crash-report): remove crash report banner functionality on launch\r\n\r\n\r\n**Full Changelog**: https://github.com/kodjodevf/mangayomi/compare/v0.9.0...v0.9.1",
-          "downloadURL": "https://github.com/kodjodevf/mangayomi/releases/download/v0.9.1/Mangayomi-v0.9.1-ios.ipa",
-          "size": 109840449
+          "version": "0.9.2",
+          "date": "2026-09-03",
+          "localizedDescription": "## What's Changed\r\n* Add assets to constant file by @NBA2K1 in https://github.com/kodjodevf/mangayomi/pull/968\r\n* fix: triage error reports and resolve reported crashes by @mrandhawa14 in https://github.com/kodjodevf/mangayomi/pull/970\r\n* feat(experimental): add support for Aidoku extensions by @kodjodevf in https://github.com/kodjodevf/mangayomi/pull/969\r\n* Optimize local image-folder pages and image handling by @NBA2K1 in https://github.com/kodjodevf/mangayomi/pull/973\r\n\r\n\r\n**Full Changelog**: https://github.com/kodjodevf/mangayomi/compare/v0.9.1...v0.9.2",
+          "downloadURL": "https://github.com/kodjodevf/mangayomi/releases/download/v0.9.2/Mangayomi-v0.9.2-ios.ipa",
+          "size": 114010180
         }
       ]
     },
@@ -386,10 +386,10 @@
       "versions": [
         {
           "version": "1.2.3",
-          "date": "2026-08-28",
-          "localizedDescription": "MoviePilot Release\n\n- Version: 1.2.3\n- Build Date: 2026-08-28\n- Android: Signed APK\n- iOS: Unsigned IPA\n\niOS 安装说明：\n- IPA 为未签名包\n- 请使用自己的 Apple Developer 账号通过 AltStore、Sideloadly 或 Xcode 进行签名安装\n\n\n## What's Changed\n* fix: 兼容 MoviePilot v3 媒体身份契约，修复 v3 服务端下详情页 422 by @sokouu87 in https://github.com/singleton-altman/MoviePilotLite/pull/97\n* fix: 适配 MoviePilot v3 的统一响应 envelope（仪表盘数值为 0 / 详情页仍 422） by @sokouu87 in https://github.com/singleton-altman/MoviePilotLite/pull/98\n\n## New Contributors\n* @sokouu87 made their first contribution in https://github.com/singleton-altman/MoviePilotLite/pull/97\n\n**Full Changelog**: https://github.com/singleton-altman/MoviePilotLite/compare/release-v1.2.3-2026-08-07...release-v1.2.3-2026-08-28",
-          "downloadURL": "https://github.com/singleton-altman/MoviePilotLite/releases/download/release-v1.2.3-2026-08-28/ios-v1.2.3-2026-08-28.ipa",
-          "size": 35162118,
+          "date": "2026-09-04",
+          "localizedDescription": "MoviePilot Release\n\n- Version: 1.2.3\n- Build Date: 2026-09-04\n- Android: Signed APK\n- iOS: Unsigned IPA\n\niOS 安装说明：\n- IPA 为未签名包\n- 请使用自己的 Apple Developer 账号通过 AltStore、Sideloadly 或 Xcode 进行签名安装\n\n\n## What's Changed\n* fix: 修复 v3 下搜索结果显示「未知标题」（服务端 response_model 错误的客户端兜底） by @sokouu87 in https://github.com/singleton-altman/MoviePilotLite/pull/101\n* fix: 清理 v3 下已失效的旧媒体 ID 字段与消失的存储用量端点 by @sokouu87 in https://github.com/singleton-altman/MoviePilotLite/pull/102\n\n\n**Full Changelog**: https://github.com/singleton-altman/MoviePilotLite/compare/release-v1.2.3-2026-08-25...release-v1.2.3-2026-09-04",
+          "downloadURL": "https://github.com/singleton-altman/MoviePilotLite/releases/download/release-v1.2.3-2026-09-04/ios-v1.2.3-2026-09-04.ipa",
+          "size": 35155525,
           "minOSVersion": "15.0"
         }
       ]
@@ -433,12 +433,12 @@
       "tintColor": "#73b480",
       "versions": [
         {
-          "version": "2.1.2",
-          "buildVersion": "5281",
-          "date": "2026-08-30",
-          "localizedDescription": "修复 bug",
-          "downloadURL": "https://github.com/bggRGjQaUbCoE/PiliPlus/releases/download/2.1.2.3/PiliPlus_ios_2.1.2%2B5281.ipa",
-          "size": 23936722,
+          "version": "2.1.3",
+          "buildVersion": "5315",
+          "date": "2026-09-05",
+          "localizedDescription": "限制直播聊天缓存条目\r\n音频播放页配置音量均衡 #2598 by @Eazed-Yu\r\n限制离线弹幕下载并发 #2800 by @KIDA-MNESIA\r\n关注分组支持切换排序方式 #2772 co-by @defghy\r\nLinux 支持 WebView #2843 by @Tobiichi-Origuchi\r\n支持显示定时关闭剩余时间 #2461 co-by @SXP-Simon\r\n更新直播弹幕屏蔽页面，实现直播弹幕屏蔽 #2821 by @Starfallan\r\niOS 设置 `ITSAppUsesNonExemptEncryption` 属性 #2789 by @maoawa\r\n评论输入框增加 LaTeX 公式转 Unicode 开关 #2792 by @milk2715093695\r\n修复部分视频画质切换问题 #2810 #2828 by @TomorrowX6 co-by @My-Responsitories\r\n\r\n优化字体自重 #2787 by @My-Responsitories\r\n优化/修复账号逻辑 #2794 #2797 by @KIDA-MNESIA #2817 by @My-Responsitories\r\n\r\n修复 #2709 #2816 #2836 #2837",
+          "downloadURL": "https://github.com/bggRGjQaUbCoE/PiliPlus/releases/download/2.1.3.1/PiliPlus_ios_2.1.3%2B5315.ipa",
+          "size": 23970852,
           "minOSVersion": "14.0"
         }
       ]
@@ -482,11 +482,11 @@
       "tintColor": "#50B0F0",
       "versions": [
         {
-          "version": "3.1.0",
-          "date": "2026-09-02",
-          "localizedDescription": "# 纯粹直播 v3.1.0\r\n\r\n|版本|下载地址|\r\n|---|---|\r\n|TV版|[pure_live_TV](https://github.com/liuchuancong/pure_live_TV/releases/latest)|\r\n|Windows/macOS/Android/iOS版|[pure_live](https://github.com/liuchuancong/pure_live/releases/latest)|\r\n\r\n### 🖥️ Windows 版\r\n- **Portable ZIP**：解压即用，无需安装\r\n- **EXE 安装包**：适合所有用户\r\n- **MSIX 包**：现代应用格式，支持干净卸载\r\n- 适配：Windows 10/11 x64\r\n\r\n### 🍎 macOS 版\r\n- macOS 桌面版\r\n- Universal：Apple Silicon + Intel\r\n- ZIP / DMG\r\n\r\n### 📱 Android 版\r\n- Android 8.0+（API 26，FFmpegKit 录制依赖要求）\r\n- ARM64-v8a\r\n- ARMv7\r\n- x86_64\r\n- 统一 SHA256 校验文件：[**ANDROID_SHA256SUM.txt**](https://github.com/liuchuancong/pure_live/releases/download/v3.1.0/ANDROID_SHA256SUM.txt)\r\n\r\n### 🐧 Linux 版\r\n- Linux x64\r\n- Portable tar.gz\r\n\r\n### 🍎 iOS 版\r\n- unsigned iOS device application\r\n- TrollStore / ad-hoc IPA\r\n- ARM64\r\n\r\n### 🔧 Build Metadata\r\n[**BUILD_METADATA.json**](https://github.com/liuchuancong/pure_live/releases/download/v3.1.0/BUILD_METADATA.json)\r\n\r\n### 📝 本次更新\r\nversion: 3.0.10\r\n版本更新：\r\n- 优化MPV播放器用戶可自行设置配置。\r\n- 优化化设备同步。\r\n- 添加自定义房间显示->主题-房间卡片设置。\r\n- 修复录制任务中保持活跃。\r\n- 修复多画面返回。\r\n- 添加本地互动开关。",
-          "downloadURL": "https://github.com/liuchuancong/pure_live/releases/download/v3.1.0/PureLive-3.0.10-4098-ios-arm64-trollstore.ipa",
-          "size": 59313372,
+          "version": "3.1.2",
+          "date": "2026-09-04",
+          "localizedDescription": "# 纯粹直播 v3.1.2\n\n|版本|下载地址|\n|---|---|\n|TV版|[pure_live_TV](https://github.com/liuchuancong/pure_live_TV/releases/latest)|\n|Windows/macOS/Android/iOS版|[pure_live](https://github.com/liuchuancong/pure_live/releases/latest)|\n\n### 🖥️ Windows 版\n\n- **Portable ZIP**：解压即用，无需安装\n- **EXE 安装包**：适合所有用户\n- **MSIX 包**：现代应用格式，支持干净卸载\n- 适配：Windows 10/11 x64\n\n### 🍎 macOS 版\n\n- macOS 桌面版\n- Universal：Apple Silicon + Intel\n- ZIP / DMG\n\n### 📱 Android 版\n\n- Android 8.0+（API 26，FFmpegKit 录制依赖要求）\n- ARM64-v8a\n- ARMv7\n- x86_64\n- 统一 SHA256 校验文件：[**ANDROID_SHA256SUM.txt**](https://github.com/liuchuancong/pure_live/releases/download/v3.1.2/ANDROID_SHA256SUM.txt)\n\n### 🐧 Linux 版\n\n- Linux x64\n- Portable tar.gz\n\n### 🍎 iOS 版\n\n- unsigned iOS device application\n- TrollStore / ad-hoc IPA\n- ARM64\n\n### 🔧 Build Metadata\n\n[**BUILD_METADATA.json**](https://github.com/liuchuancong/pure_live/releases/download/v3.1.2/BUILD_METADATA.json)\n\n### 📝 本次更新\n\nversion: 3.1.2\n版本更新：\n- 修复ijk播放器黑屏。\n- 添加多画面静音。\n- 其他bug。",
+          "downloadURL": "https://github.com/liuchuancong/pure_live/releases/download/v3.1.2/PureLive-3.1.2-4100-ios-arm64-trollstore.ipa",
+          "size": 59369697,
           "minOSVersion": "15.6"
         }
       ]
@@ -638,26 +638,81 @@
   ],
   "news": [
     {
+      "appID": "com.example.piliplus",
+      "title": "PiliPlus 2.1.3 · 05 Sep 2026",
+      "identifier": "PiliPlus-release-2.1.3.1",
+      "caption": "PiliPlus 2.1.3 is available.",
+      "date": "2026-09-05T04:43:21Z",
+      "tintColor": "#73b480",
+      "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/PiliPlus/images/news.png",
+      "notify": true,
+      "url": "https://github.com/bggRGjQaUbCoE/PiliPlus/releases/tag/2.1.3.1"
+    },
+    {
       "appID": "com.armsx2.ios",
-      "title": "ARMSX2 nightly-20260902 · 02 Sep 2026",
-      "identifier": "ARMSX2-release-nightly-20260902",
-      "caption": "ARMSX2 nightly-20260902 is available.",
-      "date": "2026-09-02T21:07:50Z",
+      "title": "ARMSX2 nightly-20260904 · 04 Sep 2026",
+      "identifier": "ARMSX2-release-nightly-20260904",
+      "caption": "ARMSX2 nightly-20260904 is available.",
+      "date": "2026-09-04T13:12:31Z",
       "tintColor": "#3CAEFF",
       "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/ARMSX2/images/news.png",
       "notify": true,
-      "url": "https://github.com/ARMSX2/ARMSX2/releases/tag/nightly-20260902"
+      "url": "https://github.com/ARMSX2/ARMSX2/releases/tag/nightly-20260904"
+    },
+    {
+      "appID": "sb.moe.kumone",
+      "title": "Kumone 0.3.16 · 04 Sep 2026",
+      "identifier": "Kumone-release-v0.3.16",
+      "caption": "Kumone 0.3.16 is available.",
+      "date": "2026-09-04T06:38:46Z",
+      "tintColor": "#F0D060",
+      "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/Kumone/images/news.png",
+      "notify": true,
+      "url": "https://github.com/missuo/kumone/releases/tag/v0.3.16"
     },
     {
       "appID": "com.mystyle.purelive.liu",
-      "title": "PureLive 3.1.0 · 02 Sep 2026",
-      "identifier": "PureLive-release-v3.1.0",
-      "caption": "PureLive 3.1.0 is available.",
-      "date": "2026-09-02T14:34:19Z",
+      "title": "PureLive 3.1.2 · 04 Sep 2026",
+      "identifier": "PureLive-release-v3.1.2",
+      "caption": "PureLive 3.1.2 is available.",
+      "date": "2026-09-04T03:52:13Z",
       "tintColor": "#50B0F0",
       "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/PureLive/images/news.png",
       "notify": true,
-      "url": "https://github.com/liuchuancong/pure_live/releases/tag/v3.1.0"
+      "url": "https://github.com/liuchuancong/pure_live/releases/tag/v3.1.2"
+    },
+    {
+      "appID": "com.altman.moviepilot",
+      "title": "MoviePilotLite 1.2.3 · 04 Sep 2026",
+      "identifier": "MoviePilotLite-release-release-v1.2.3-2026-09-04",
+      "caption": "MoviePilotLite 1.2.3 is available.",
+      "date": "2026-09-04T03:07:38Z",
+      "tintColor": "#8050F0",
+      "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/MoviePilotLite/images/news.png",
+      "notify": true,
+      "url": "https://github.com/singleton-altman/MoviePilotLite/releases/tag/release-v1.2.3-2026-09-04"
+    },
+    {
+      "appID": "app.aidoku.Aidoku",
+      "title": "Aidoku 0.9 · 03 Sep 2026",
+      "identifier": "Aidoku-release-v0.9",
+      "caption": "Aidoku 0.9 is available.",
+      "date": "2026-09-03T20:17:08Z",
+      "tintColor": "#FF375F",
+      "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/Aidoku/images/news.png",
+      "notify": true,
+      "url": "https://github.com/Aidoku/Aidoku/releases/tag/v0.9"
+    },
+    {
+      "appID": "com.kodjodevf.mangayomi",
+      "title": "Mangayomi 0.9.2 · 03 Sep 2026",
+      "identifier": "Mangayomi-release-v0.9.2",
+      "caption": "Mangayomi 0.9.2 is available.",
+      "date": "2026-09-03T13:58:24Z",
+      "tintColor": "#EF4444",
+      "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/Mangayomi/images/news.png",
+      "notify": true,
+      "url": "https://github.com/kodjodevf/mangayomi/releases/tag/v0.9.2"
     },
     {
       "appID": "com.miguel.psx3ios",
@@ -669,17 +724,6 @@
       "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/PSX3IOS/images/news.png",
       "notify": true,
       "url": "https://github.com/xmiguel911x/PSX3IOS/releases/tag/v0.2.7-beta"
-    },
-    {
-      "appID": "com.kodjodevf.mangayomi",
-      "title": "Mangayomi 0.9.1 · 01 Sep 2026",
-      "identifier": "Mangayomi-release-v0.9.1",
-      "caption": "Mangayomi 0.9.1 is available.",
-      "date": "2026-09-01T12:09:54Z",
-      "tintColor": "#EF4444",
-      "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/Mangayomi/images/news.png",
-      "notify": true,
-      "url": "https://github.com/kodjodevf/mangayomi/releases/tag/v0.9.1"
     },
     {
       "appID": "com.naine.doer",
@@ -704,28 +748,6 @@
       "url": "https://github.com/CyrilPeng/Venera-Next/releases/tag/v1.15.0"
     },
     {
-      "appID": "com.example.piliplus",
-      "title": "PiliPlus 2.1.2 · 30 Aug 2026",
-      "identifier": "PiliPlus-release-2.1.2.3",
-      "caption": "PiliPlus 2.1.2 is available.",
-      "date": "2026-08-30T04:20:00Z",
-      "tintColor": "#73b480",
-      "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/PiliPlus/images/news.png",
-      "notify": true,
-      "url": "https://github.com/bggRGjQaUbCoE/PiliPlus/releases/tag/2.1.2.3"
-    },
-    {
-      "appID": "sb.moe.kumone",
-      "title": "Kumone 0.3.14 · 29 Aug 2026",
-      "identifier": "Kumone-release-v0.3.14",
-      "caption": "Kumone 0.3.14 is available.",
-      "date": "2026-08-29T12:43:10Z",
-      "tintColor": "#F0D060",
-      "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/Kumone/images/news.png",
-      "notify": true,
-      "url": "https://github.com/missuo/kumone/releases/tag/v0.3.14"
-    },
-    {
       "appID": "org.animeko.animeko",
       "title": "Animeko 6.1.0 · 28 Aug 2026",
       "identifier": "Animeko-release-v6.1.0",
@@ -746,17 +768,6 @@
       "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/AnimeFlow/images/news.png",
       "notify": true,
       "url": "https://github.com/openAnimeFlow/AnimeFlow/releases/tag/v2.4.0"
-    },
-    {
-      "appID": "com.altman.moviepilot",
-      "title": "MoviePilotLite 1.2.3 · 28 Aug 2026",
-      "identifier": "MoviePilotLite-release-release-v1.2.3-2026-08-28",
-      "caption": "MoviePilotLite 1.2.3 is available.",
-      "date": "2026-08-28T09:44:29Z",
-      "tintColor": "#8050F0",
-      "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/MoviePilotLite/images/news.png",
-      "notify": true,
-      "url": "https://github.com/singleton-altman/MoviePilotLite/releases/tag/release-v1.2.3-2026-08-28"
     },
     {
       "appID": "com.example.kazumi",
@@ -878,17 +889,6 @@
       "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/master/apps/LiveContainer+SideStore/images/news.png",
       "notify": true,
       "url": "https://github.com/LiveContainer/LiveContainer/releases/tag/3.8.0"
-    },
-    {
-      "appID": "app.aidoku.Aidoku",
-      "title": "Aidoku 0.8.4 · 03 Jul 2026",
-      "identifier": "Aidoku-release-v0.8.4",
-      "caption": "Aidoku 0.8.4 is available.",
-      "date": "2026-07-03T05:27:41Z",
-      "tintColor": "#FF375F",
-      "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/Aidoku/images/news.png",
-      "notify": true,
-      "url": "https://github.com/Aidoku/Aidoku/releases/tag/v0.8.4"
     },
     {
       "appID": "com.mafty.dukex",

--- a/all-apps.json
+++ b/all-apps.json
@@ -433,7 +433,7 @@
       "tintColor": "#73b480",
       "versions": [
         {
-          "version": "2.1.2.3",
+          "version": "2.1.2",
           "buildVersion": "5281",
           "date": "2026-08-30",
           "localizedDescription": "修复 bug",
@@ -705,9 +705,9 @@
     },
     {
       "appID": "com.example.piliplus",
-      "title": "PiliPlus 2.1.2.3 · 30 Aug 2026",
+      "title": "PiliPlus 2.1.2 · 30 Aug 2026",
       "identifier": "PiliPlus-release-2.1.2.3",
-      "caption": "PiliPlus 2.1.2.3 is available.",
+      "caption": "PiliPlus 2.1.2 is available.",
       "date": "2026-08-30T04:20:00Z",
       "tintColor": "#73b480",
       "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/PiliPlus/images/news.png",

--- a/apps/ARMSX2/apps.json
+++ b/apps/ARMSX2/apps.json
@@ -21,11 +21,11 @@
       "tintColor": "#3CAEFF",
       "versions": [
         {
-          "version": "nightly-20260902",
-          "date": "2026-09-02",
-          "localizedDescription": "Automated nightly build for community testing (unsigned).\n\nEvery download is named `ARMSX2-nightly-DATE-COMMIT-PLATFORM`, so builds\nfrom different nights stay distinguishable after you have downloaded them.\n\n- macOS arm64: macOS-arm64.tar.xz\n- Linux arm64: Linux-arm64-4K-pages.AppImage on most distros, or the 16K one on Asahi Linux and other Apple Silicon kernels (run getconf PAGESIZE if unsure)\n- Windows arm64: Windows-arm64.zip\n- RetroArch on Linux arm64: Linux-arm64-libretro-core.tar.zst, a 4K-page build\n- Bare-display kmsdrm handhelds: Linux-arm64-SDL-handheld.tar.zst, a 4K-page build (Rocknix and Batocera run compositors, so use the Qt AppImage there instead)\n- Android: Android-arm64.apk, sideload it\n- iOS: iOS-arm64.ipa, unsigned, sideload it\n\n## What's new\n- VU div unit: gate the console ceiling on the clamp mode\n\nFull changelog: https://github.com/ARMSX2/ARMSX2/compare/nightly-20260901...82b3e3ece4afa627e64d0cc01bc175d06029d2d8",
-          "downloadURL": "https://github.com/ARMSX2/ARMSX2/releases/download/nightly-20260902/ARMSX2-nightly-20260902-82b3e3ece4-iOS-arm64.ipa",
-          "size": 26744122,
+          "version": "nightly-20260904",
+          "date": "2026-09-04",
+          "localizedDescription": "Automated nightly build for community testing (unsigned).\n\nEvery download is named `ARMSX2-nightly-DATE-COMMIT-PLATFORM`, so builds\nfrom different nights stay distinguishable after you have downloaded them.\n\n- macOS arm64: macOS-arm64.tar.xz\n- Linux arm64: Linux-arm64-4K-pages.AppImage on most distros, or the 16K one on Asahi Linux and other Apple Silicon kernels (run getconf PAGESIZE if unsure)\n- Windows arm64: Windows-arm64.zip\n- RetroArch on Linux arm64: Linux-arm64-libretro-core.tar.zst, a 4K-page build\n- Bare-display kmsdrm handhelds: Linux-arm64-SDL-handheld.tar.zst, a 4K-page build (Rocknix and Batocera run compositors, so use the Qt AppImage there instead)\n- Android: Android-arm64.apk, sideload it\n- iOS: iOS-arm64.ipa, unsigned, sideload it\n\n## What's new\n- Pad: bring over the ARMSX3 controller work\n- Pad: let the user choose the rumble fallback for motorless pads (#646)\n- Quick loading: drop each extracted file from the page cache\n- Affinity: Sustained Performance wins over Performance Cores\n\nFull changelog: https://github.com/ARMSX2/ARMSX2/compare/nightly-20260903...aa2a43fffc951d65807600edfc2ff85250677714",
+          "downloadURL": "https://github.com/ARMSX2/ARMSX2/releases/download/nightly-20260904/ARMSX2-nightly-20260904-aa2a43fffc-iOS-arm64.ipa",
+          "size": 26743091,
           "minOSVersion": "17.0"
         }
       ]
@@ -34,14 +34,14 @@
   "news": [
     {
       "appID": "com.armsx2.ios",
-      "title": "ARMSX2 nightly-20260902 · 02 Sep 2026",
-      "identifier": "ARMSX2-release-nightly-20260902",
-      "caption": "ARMSX2 nightly-20260902 is available.",
-      "date": "2026-09-02T21:07:50Z",
+      "title": "ARMSX2 nightly-20260904 · 04 Sep 2026",
+      "identifier": "ARMSX2-release-nightly-20260904",
+      "caption": "ARMSX2 nightly-20260904 is available.",
+      "date": "2026-09-04T13:12:31Z",
       "tintColor": "#3CAEFF",
       "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/ARMSX2/images/news.png",
       "notify": true,
-      "url": "https://github.com/ARMSX2/ARMSX2/releases/tag/nightly-20260902"
+      "url": "https://github.com/ARMSX2/ARMSX2/releases/tag/nightly-20260904"
     }
   ]
 }

--- a/apps/Aidoku/apps.json
+++ b/apps/Aidoku/apps.json
@@ -21,11 +21,11 @@
       "tintColor": "#FF375F",
       "versions": [
         {
-          "version": "0.8.4",
-          "date": "2026-07-03",
-          "localizedDescription": "- Fixes for iOS 27: fixed settings pages freezing the app, along with other minor visual issues.\r\n- Improved backup restore time: restores should now take seconds instead of minutes. (@Amqx)\r\n- Failed download page retrying: less chance of missing pages in downloaded chapters from sources with aggressive rate limits. (@pxseu)\r\n- New chapter notifications (experimental): when Aidoku refreshes in the background, notification(s) of new chapters should be sent if enabled. (@Zareix)\r\n- Various other bug fixes and small features: see [the website](<https://aidoku.app/release-notes/>) for a more complete list.",
-          "downloadURL": "https://github.com/Aidoku/Aidoku/releases/download/v0.8.4/Aidoku.ipa",
-          "size": 10136987,
+          "version": "0.9",
+          "date": "2026-09-03",
+          "localizedDescription": "- OCR dictionary support (iOS 18+): import Yomitan-compatible dictionaries in the app and look up words while reading.\r\n- Suwayomi built-in source: read and track from a Suwayomi instance, just like Komga and Kavita.\r\n- Auto scroll for webtoon reader: enable and press the play button to scroll without touching your device.\r\n- Fixed CloudFlare handling: CloudFlare issues that caused external sources to break should be resolved.\r\n- Overall performance improvements: the library loads much faster (@Amqx), and the webtoon reader was improved.\r\n- Source stability fixes and disable option: the issue where sources were causing the app to crash should not happen again, and now you can even disable a source that is broken until it receives an update.\r\n- Many more things: see [the website](https://aidoku.app/release-notes/) for a more complete list.",
+          "downloadURL": "https://github.com/Aidoku/Aidoku/releases/download/v0.9/Aidoku.ipa",
+          "size": 11864382,
           "minOSVersion": "15.0"
         }
       ]
@@ -34,14 +34,14 @@
   "news": [
     {
       "appID": "app.aidoku.Aidoku",
-      "title": "Aidoku 0.8.4 · 03 Jul 2026",
-      "identifier": "Aidoku-release-v0.8.4",
-      "caption": "Aidoku 0.8.4 is available.",
-      "date": "2026-07-03T05:27:41Z",
+      "title": "Aidoku 0.9 · 03 Sep 2026",
+      "identifier": "Aidoku-release-v0.9",
+      "caption": "Aidoku 0.9 is available.",
+      "date": "2026-09-03T20:17:08Z",
       "tintColor": "#FF375F",
       "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/Aidoku/images/news.png",
       "notify": true,
-      "url": "https://github.com/Aidoku/Aidoku/releases/tag/v0.8.4"
+      "url": "https://github.com/Aidoku/Aidoku/releases/tag/v0.9"
     }
   ]
 }

--- a/apps/Kumone/apps.json
+++ b/apps/Kumone/apps.json
@@ -21,11 +21,11 @@
       "tintColor": "#F0D060",
       "versions": [
         {
-          "version": "0.3.14",
-          "date": "2026-08-29",
-          "localizedDescription": "### Added / 新增\n\n- **iOS + macOS**: a retro vinyl record-player now-playing mode (黑胶模式) — programmatic vinyl + tonearm with swipe-to-switch. Opt in from Settings (the default stays 沉浸模式). Thanks @MikeChongCan (#55).\n- **iOS + macOS**：新增黑胶唱片播放页模式（黑胶模式）——矢量唱片 + 唱臂，可滑动切换。默认仍是沉浸模式，可在设置中选择。感谢 @MikeChongCan（#55）。\n- **macOS**: a \"桌面歌词水平居中\" toggle that locks the floating lyric capsule to the horizontal centre of the screen (vertical drag still works). (#48)\n- **macOS**：新增「桌面歌词水平居中」开关，可把悬浮歌词锁定在屏幕水平中央（仍可上下拖动）。（#48）\n\n### Fixed / 修复\n\n- **macOS**: the desktop-lyrics button in the player bar now reflects its on/off state — it read the setting directly and never re-rendered when toggled. (#48)\n- **macOS**：播放条上的桌面歌词按钮现在会正确反映开/关状态——之前直接读取设置、切换后不重绘，颜色卡住。（#48）",
-          "downloadURL": "https://github.com/missuo/kumone/releases/download/v0.3.14/Kumone-iOS-0.3.14.ipa",
-          "size": 7137029,
+          "version": "0.3.16",
+          "date": "2026-09-04",
+          "localizedDescription": "### Added / 新增\n\n- **iOS**: CarPlay Now Playing gains a working Up Next button — tapping it pushes the live playback queue (current track pinned on top, up to 300 upcoming rows), and picking a row jumps straight to that track. Outside FM mode the button row also gains 随机 and 循环 controls whose icons track `shuffleEnabled` / `repeatMode`, and the album-artist button opens the current track's album (falling back to its first artist for cloud-disk tracks with no album). Thanks @MikeChongCan (#54).\n- **iOS**：CarPlay Now Playing 的「播放队列」按钮现在可用——点击弹出实时播放队列（当前曲目置顶，最多 300 条待播），点任意一行直接跳转播放。非 FM 模式下按钮区新增 随机 / 循环 控件，图标跟随 `shuffleEnabled` 与 `repeatMode` 变化；专辑歌手按钮可跳转当前曲目的专辑（云盘歌曲等无专辑信息时回退到第一位歌手）。感谢 @MikeChongCan（#54）。\n- **Build**: `make configure` / `make configure-carplay` select which capabilities the iOS build ships with, plus `make build` / `test` / `app` / `project` wrappers. Run `make` for the list. (#54)\n- **Build**：新增 `make configure` / `make configure-carplay` 切换 iOS 构建包含的能力，另有 `make build` / `test` / `app` / `project` 等封装。执行 `make` 查看全部目标。（#54）\n\n### Changed / 变更\n\n- **iOS**: CarPlay is now excluded from the default build entirely, not just left unsigned — `UISupportsCarPlay` and the `CPTemplateApplicationSceneSessionRoleApplication` scene declaration have moved out of `ios/Config/Info.plist` and are injected, together with the `com.apple.developer.carplay-audio` entitlement, only by `make configure-carplay`. The overlay is written to untracked files and never touches the Xcode project, so enabling CarPlay leaves the working tree clean. Replaces the previous \"uncomment `KumoneIOS.entitlements.example` by hand\" flow. (#54)\n- **iOS**：CarPlay 现在从默认构建中完全移除，而不只是不签名——`UISupportsCarPlay` 与 `CPTemplateApplicationSceneSessionRoleApplication` scene 声明已移出 `ios/Config/Info.plist`，与 `com.apple.developer.carplay-audio` entitlement 一起，仅由 `make configure-carplay` 注入。覆盖文件均不纳入 git 且完全不改动 Xcode 工程，开启 CarPlay 后工作区依然干净。取代原先手动取消注释 `KumoneIOS.entitlements.example` 的流程。（#54）\n\n### Fixed / 修复\n\n- **iOS**: the in-app updater now saves the downloaded IPA into the app's Documents folder — findable in the Files app under On My iPhone ▸ Kumone (the app now enables file sharing) — and opens a share sheet so it can be saved or handed straight to a signing tool (全能签 / ESign / AltStore …), instead of only offering an export dialog that left users unable to locate the file. (#73, #50)\n- **iOS**：应用内更新现在会把下载的 IPA 保存到 App 的 Documents 目录——可在「文件」App ▸ 我的 iPhone ▸ Kumone 里找到（已开启文件共享）——并弹出分享面板，可保存或直接导入签名工具（全能签 / ESign / AltStore 等），不再是之前那种让人找不到文件的导出弹窗。（#73，#50）",
+          "downloadURL": "https://github.com/missuo/kumone/releases/download/v0.3.16/Kumone-iOS-0.3.16.ipa",
+          "size": 7245579,
           "minOSVersion": "16.0"
         }
       ]
@@ -34,14 +34,14 @@
   "news": [
     {
       "appID": "sb.moe.kumone",
-      "title": "Kumone 0.3.14 · 29 Aug 2026",
-      "identifier": "Kumone-release-v0.3.14",
-      "caption": "Kumone 0.3.14 is available.",
-      "date": "2026-08-29T12:43:10Z",
+      "title": "Kumone 0.3.16 · 04 Sep 2026",
+      "identifier": "Kumone-release-v0.3.16",
+      "caption": "Kumone 0.3.16 is available.",
+      "date": "2026-09-04T06:38:46Z",
       "tintColor": "#F0D060",
       "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/Kumone/images/news.png",
       "notify": true,
-      "url": "https://github.com/missuo/kumone/releases/tag/v0.3.14"
+      "url": "https://github.com/missuo/kumone/releases/tag/v0.3.16"
     }
   ]
 }

--- a/apps/Mangayomi/apps.json
+++ b/apps/Mangayomi/apps.json
@@ -21,11 +21,11 @@
       "tintColor": "#EF4444",
       "versions": [
         {
-          "version": "0.9.1",
-          "date": "2026-09-01",
-          "localizedDescription": "## What's Changed\r\n* Fix cache collision via chapter hash in filename by @NBA2K1 in https://github.com/kodjodevf/mangayomi/pull/967\r\n* fix(mihon-service): update genre parsing to handle string input\r\n* refactor(crash-report): remove crash report banner functionality on launch\r\n\r\n\r\n**Full Changelog**: https://github.com/kodjodevf/mangayomi/compare/v0.9.0...v0.9.1",
-          "downloadURL": "https://github.com/kodjodevf/mangayomi/releases/download/v0.9.1/Mangayomi-v0.9.1-ios.ipa",
-          "size": 109840449
+          "version": "0.9.2",
+          "date": "2026-09-03",
+          "localizedDescription": "## What's Changed\r\n* Add assets to constant file by @NBA2K1 in https://github.com/kodjodevf/mangayomi/pull/968\r\n* fix: triage error reports and resolve reported crashes by @mrandhawa14 in https://github.com/kodjodevf/mangayomi/pull/970\r\n* feat(experimental): add support for Aidoku extensions by @kodjodevf in https://github.com/kodjodevf/mangayomi/pull/969\r\n* Optimize local image-folder pages and image handling by @NBA2K1 in https://github.com/kodjodevf/mangayomi/pull/973\r\n\r\n\r\n**Full Changelog**: https://github.com/kodjodevf/mangayomi/compare/v0.9.1...v0.9.2",
+          "downloadURL": "https://github.com/kodjodevf/mangayomi/releases/download/v0.9.2/Mangayomi-v0.9.2-ios.ipa",
+          "size": 114010180
         }
       ]
     }
@@ -33,14 +33,14 @@
   "news": [
     {
       "appID": "com.kodjodevf.mangayomi",
-      "title": "Mangayomi 0.9.1 · 01 Sep 2026",
-      "identifier": "Mangayomi-release-v0.9.1",
-      "caption": "Mangayomi 0.9.1 is available.",
-      "date": "2026-09-01T12:09:54Z",
+      "title": "Mangayomi 0.9.2 · 03 Sep 2026",
+      "identifier": "Mangayomi-release-v0.9.2",
+      "caption": "Mangayomi 0.9.2 is available.",
+      "date": "2026-09-03T13:58:24Z",
       "tintColor": "#EF4444",
       "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/Mangayomi/images/news.png",
       "notify": true,
-      "url": "https://github.com/kodjodevf/mangayomi/releases/tag/v0.9.1"
+      "url": "https://github.com/kodjodevf/mangayomi/releases/tag/v0.9.2"
     }
   ]
 }

--- a/apps/MoviePilotLite/apps.json
+++ b/apps/MoviePilotLite/apps.json
@@ -22,10 +22,10 @@
       "versions": [
         {
           "version": "1.2.3",
-          "date": "2026-08-28",
-          "localizedDescription": "MoviePilot Release\n\n- Version: 1.2.3\n- Build Date: 2026-08-28\n- Android: Signed APK\n- iOS: Unsigned IPA\n\niOS 安装说明：\n- IPA 为未签名包\n- 请使用自己的 Apple Developer 账号通过 AltStore、Sideloadly 或 Xcode 进行签名安装\n\n\n## What's Changed\n* fix: 兼容 MoviePilot v3 媒体身份契约，修复 v3 服务端下详情页 422 by @sokouu87 in https://github.com/singleton-altman/MoviePilotLite/pull/97\n* fix: 适配 MoviePilot v3 的统一响应 envelope（仪表盘数值为 0 / 详情页仍 422） by @sokouu87 in https://github.com/singleton-altman/MoviePilotLite/pull/98\n\n## New Contributors\n* @sokouu87 made their first contribution in https://github.com/singleton-altman/MoviePilotLite/pull/97\n\n**Full Changelog**: https://github.com/singleton-altman/MoviePilotLite/compare/release-v1.2.3-2026-08-07...release-v1.2.3-2026-08-28",
-          "downloadURL": "https://github.com/singleton-altman/MoviePilotLite/releases/download/release-v1.2.3-2026-08-28/ios-v1.2.3-2026-08-28.ipa",
-          "size": 35162118,
+          "date": "2026-09-04",
+          "localizedDescription": "MoviePilot Release\n\n- Version: 1.2.3\n- Build Date: 2026-09-04\n- Android: Signed APK\n- iOS: Unsigned IPA\n\niOS 安装说明：\n- IPA 为未签名包\n- 请使用自己的 Apple Developer 账号通过 AltStore、Sideloadly 或 Xcode 进行签名安装\n\n\n## What's Changed\n* fix: 修复 v3 下搜索结果显示「未知标题」（服务端 response_model 错误的客户端兜底） by @sokouu87 in https://github.com/singleton-altman/MoviePilotLite/pull/101\n* fix: 清理 v3 下已失效的旧媒体 ID 字段与消失的存储用量端点 by @sokouu87 in https://github.com/singleton-altman/MoviePilotLite/pull/102\n\n\n**Full Changelog**: https://github.com/singleton-altman/MoviePilotLite/compare/release-v1.2.3-2026-08-25...release-v1.2.3-2026-09-04",
+          "downloadURL": "https://github.com/singleton-altman/MoviePilotLite/releases/download/release-v1.2.3-2026-09-04/ios-v1.2.3-2026-09-04.ipa",
+          "size": 35155525,
           "minOSVersion": "15.0"
         }
       ]
@@ -34,14 +34,14 @@
   "news": [
     {
       "appID": "com.altman.moviepilot",
-      "title": "MoviePilotLite 1.2.3 · 28 Aug 2026",
-      "identifier": "MoviePilotLite-release-release-v1.2.3-2026-08-28",
+      "title": "MoviePilotLite 1.2.3 · 04 Sep 2026",
+      "identifier": "MoviePilotLite-release-release-v1.2.3-2026-09-04",
       "caption": "MoviePilotLite 1.2.3 is available.",
-      "date": "2026-08-28T09:44:29Z",
+      "date": "2026-09-04T03:07:38Z",
       "tintColor": "#8050F0",
       "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/MoviePilotLite/images/news.png",
       "notify": true,
-      "url": "https://github.com/singleton-altman/MoviePilotLite/releases/tag/release-v1.2.3-2026-08-28"
+      "url": "https://github.com/singleton-altman/MoviePilotLite/releases/tag/release-v1.2.3-2026-09-04"
     }
   ]
 }

--- a/apps/PiliPlus/apps.json
+++ b/apps/PiliPlus/apps.json
@@ -8,7 +8,7 @@
   "apps": [
     {
       "name": "PiliPlus",
-      "bundleIdentifier": "com.example.PiliPlus",
+      "bundleIdentifier": "com.example.piliplus",
       "developerName": "bggRGjQaUbCoE",
       "subtitle": "使用Flutter开发的BiliBili第三方客户端",
       "localizedDescription": "使用Flutter开发的BiliBili第三方客户端",
@@ -34,7 +34,7 @@
   ],
   "news": [
     {
-      "appID": "com.example.PiliPlus",
+      "appID": "com.example.piliplus",
       "title": "PiliPlus 2.1.2.3 · 30 Aug 2026",
       "identifier": "PiliPlus-release-2.1.2.3",
       "caption": "PiliPlus 2.1.2.3 is available.",

--- a/apps/PiliPlus/apps.json
+++ b/apps/PiliPlus/apps.json
@@ -21,12 +21,12 @@
       "tintColor": "#73b480",
       "versions": [
         {
-          "version": "2.1.2",
-          "buildVersion": "5281",
-          "date": "2026-08-30",
-          "localizedDescription": "修复 bug",
-          "downloadURL": "https://github.com/bggRGjQaUbCoE/PiliPlus/releases/download/2.1.2.3/PiliPlus_ios_2.1.2%2B5281.ipa",
-          "size": 23936722,
+          "version": "2.1.3",
+          "buildVersion": "5315",
+          "date": "2026-09-05",
+          "localizedDescription": "限制直播聊天缓存条目\r\n音频播放页配置音量均衡 #2598 by @Eazed-Yu\r\n限制离线弹幕下载并发 #2800 by @KIDA-MNESIA\r\n关注分组支持切换排序方式 #2772 co-by @defghy\r\nLinux 支持 WebView #2843 by @Tobiichi-Origuchi\r\n支持显示定时关闭剩余时间 #2461 co-by @SXP-Simon\r\n更新直播弹幕屏蔽页面，实现直播弹幕屏蔽 #2821 by @Starfallan\r\niOS 设置 `ITSAppUsesNonExemptEncryption` 属性 #2789 by @maoawa\r\n评论输入框增加 LaTeX 公式转 Unicode 开关 #2792 by @milk2715093695\r\n修复部分视频画质切换问题 #2810 #2828 by @TomorrowX6 co-by @My-Responsitories\r\n\r\n优化字体自重 #2787 by @My-Responsitories\r\n优化/修复账号逻辑 #2794 #2797 by @KIDA-MNESIA #2817 by @My-Responsitories\r\n\r\n修复 #2709 #2816 #2836 #2837",
+          "downloadURL": "https://github.com/bggRGjQaUbCoE/PiliPlus/releases/download/2.1.3.1/PiliPlus_ios_2.1.3%2B5315.ipa",
+          "size": 23970852,
           "minOSVersion": "14.0"
         }
       ]
@@ -35,14 +35,14 @@
   "news": [
     {
       "appID": "com.example.piliplus",
-      "title": "PiliPlus 2.1.2 · 30 Aug 2026",
-      "identifier": "PiliPlus-release-2.1.2.3",
-      "caption": "PiliPlus 2.1.2 is available.",
-      "date": "2026-08-30T04:20:00Z",
+      "title": "PiliPlus 2.1.3 · 05 Sep 2026",
+      "identifier": "PiliPlus-release-2.1.3.1",
+      "caption": "PiliPlus 2.1.3 is available.",
+      "date": "2026-09-05T04:43:21Z",
       "tintColor": "#73b480",
       "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/PiliPlus/images/news.png",
       "notify": true,
-      "url": "https://github.com/bggRGjQaUbCoE/PiliPlus/releases/tag/2.1.2.3"
+      "url": "https://github.com/bggRGjQaUbCoE/PiliPlus/releases/tag/2.1.3.1"
     }
   ]
 }

--- a/apps/PiliPlus/apps.json
+++ b/apps/PiliPlus/apps.json
@@ -21,7 +21,7 @@
       "tintColor": "#73b480",
       "versions": [
         {
-          "version": "2.1.2.3",
+          "version": "2.1.2",
           "buildVersion": "5281",
           "date": "2026-08-30",
           "localizedDescription": "修复 bug",
@@ -35,9 +35,9 @@
   "news": [
     {
       "appID": "com.example.piliplus",
-      "title": "PiliPlus 2.1.2.3 · 30 Aug 2026",
+      "title": "PiliPlus 2.1.2 · 30 Aug 2026",
       "identifier": "PiliPlus-release-2.1.2.3",
-      "caption": "PiliPlus 2.1.2.3 is available.",
+      "caption": "PiliPlus 2.1.2 is available.",
       "date": "2026-08-30T04:20:00Z",
       "tintColor": "#73b480",
       "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/PiliPlus/images/news.png",

--- a/apps/PiliPlus/config.toml
+++ b/apps/PiliPlus/config.toml
@@ -14,7 +14,7 @@ tint_color = "#00AEEF"
 
 [app]
 name = "PiliPlus"
-bundle_identifier = "com.example.PiliPlus"
+bundle_identifier = "com.example.piliplus"
 developer_name = "bggRGjQaUbCoE"
 subtitle = "使用Flutter开发的BiliBili第三方客户端"
 description = "使用Flutter开发的BiliBili第三方客户端"

--- a/apps/PiliPlus/config.toml
+++ b/apps/PiliPlus/config.toml
@@ -30,6 +30,7 @@ min_os_version = "14.0"
 [versions]
 strip_v_prefix = true
 include_prereleases = false
+version_pattern = "^(\\d+\\.\\d+\\.\\d+)"
 # asset_pattern is a regex (not glob): .*\.ipa$ matches all ipa assets
 # Compatible with two historical naming schemes: PiliPlus_ios_*.ipa and ios-release-no-sign.ipa
 asset_pattern = ".*\\.ipa$"

--- a/apps/PureLive/apps.json
+++ b/apps/PureLive/apps.json
@@ -21,11 +21,11 @@
       "tintColor": "#50B0F0",
       "versions": [
         {
-          "version": "3.1.0",
-          "date": "2026-09-02",
-          "localizedDescription": "# 纯粹直播 v3.1.0\r\n\r\n|版本|下载地址|\r\n|---|---|\r\n|TV版|[pure_live_TV](https://github.com/liuchuancong/pure_live_TV/releases/latest)|\r\n|Windows/macOS/Android/iOS版|[pure_live](https://github.com/liuchuancong/pure_live/releases/latest)|\r\n\r\n### 🖥️ Windows 版\r\n- **Portable ZIP**：解压即用，无需安装\r\n- **EXE 安装包**：适合所有用户\r\n- **MSIX 包**：现代应用格式，支持干净卸载\r\n- 适配：Windows 10/11 x64\r\n\r\n### 🍎 macOS 版\r\n- macOS 桌面版\r\n- Universal：Apple Silicon + Intel\r\n- ZIP / DMG\r\n\r\n### 📱 Android 版\r\n- Android 8.0+（API 26，FFmpegKit 录制依赖要求）\r\n- ARM64-v8a\r\n- ARMv7\r\n- x86_64\r\n- 统一 SHA256 校验文件：[**ANDROID_SHA256SUM.txt**](https://github.com/liuchuancong/pure_live/releases/download/v3.1.0/ANDROID_SHA256SUM.txt)\r\n\r\n### 🐧 Linux 版\r\n- Linux x64\r\n- Portable tar.gz\r\n\r\n### 🍎 iOS 版\r\n- unsigned iOS device application\r\n- TrollStore / ad-hoc IPA\r\n- ARM64\r\n\r\n### 🔧 Build Metadata\r\n[**BUILD_METADATA.json**](https://github.com/liuchuancong/pure_live/releases/download/v3.1.0/BUILD_METADATA.json)\r\n\r\n### 📝 本次更新\r\nversion: 3.0.10\r\n版本更新：\r\n- 优化MPV播放器用戶可自行设置配置。\r\n- 优化化设备同步。\r\n- 添加自定义房间显示->主题-房间卡片设置。\r\n- 修复录制任务中保持活跃。\r\n- 修复多画面返回。\r\n- 添加本地互动开关。",
-          "downloadURL": "https://github.com/liuchuancong/pure_live/releases/download/v3.1.0/PureLive-3.0.10-4098-ios-arm64-trollstore.ipa",
-          "size": 59313372,
+          "version": "3.1.2",
+          "date": "2026-09-04",
+          "localizedDescription": "# 纯粹直播 v3.1.2\n\n|版本|下载地址|\n|---|---|\n|TV版|[pure_live_TV](https://github.com/liuchuancong/pure_live_TV/releases/latest)|\n|Windows/macOS/Android/iOS版|[pure_live](https://github.com/liuchuancong/pure_live/releases/latest)|\n\n### 🖥️ Windows 版\n\n- **Portable ZIP**：解压即用，无需安装\n- **EXE 安装包**：适合所有用户\n- **MSIX 包**：现代应用格式，支持干净卸载\n- 适配：Windows 10/11 x64\n\n### 🍎 macOS 版\n\n- macOS 桌面版\n- Universal：Apple Silicon + Intel\n- ZIP / DMG\n\n### 📱 Android 版\n\n- Android 8.0+（API 26，FFmpegKit 录制依赖要求）\n- ARM64-v8a\n- ARMv7\n- x86_64\n- 统一 SHA256 校验文件：[**ANDROID_SHA256SUM.txt**](https://github.com/liuchuancong/pure_live/releases/download/v3.1.2/ANDROID_SHA256SUM.txt)\n\n### 🐧 Linux 版\n\n- Linux x64\n- Portable tar.gz\n\n### 🍎 iOS 版\n\n- unsigned iOS device application\n- TrollStore / ad-hoc IPA\n- ARM64\n\n### 🔧 Build Metadata\n\n[**BUILD_METADATA.json**](https://github.com/liuchuancong/pure_live/releases/download/v3.1.2/BUILD_METADATA.json)\n\n### 📝 本次更新\n\nversion: 3.1.2\n版本更新：\n- 修复ijk播放器黑屏。\n- 添加多画面静音。\n- 其他bug。",
+          "downloadURL": "https://github.com/liuchuancong/pure_live/releases/download/v3.1.2/PureLive-3.1.2-4100-ios-arm64-trollstore.ipa",
+          "size": 59369697,
           "minOSVersion": "15.6"
         }
       ]
@@ -34,14 +34,14 @@
   "news": [
     {
       "appID": "com.mystyle.purelive.liu",
-      "title": "PureLive 3.1.0 · 02 Sep 2026",
-      "identifier": "PureLive-release-v3.1.0",
-      "caption": "PureLive 3.1.0 is available.",
-      "date": "2026-09-02T14:34:19Z",
+      "title": "PureLive 3.1.2 · 04 Sep 2026",
+      "identifier": "PureLive-release-v3.1.2",
+      "caption": "PureLive 3.1.2 is available.",
+      "date": "2026-09-04T03:52:13Z",
       "tintColor": "#50B0F0",
       "imageURL": "https://raw.githubusercontent.com/bebound/AltGallery/refs/heads/master/apps/PureLive/images/news.png",
       "notify": true,
-      "url": "https://github.com/liuchuancong/pure_live/releases/tag/v3.1.0"
+      "url": "https://github.com/liuchuancong/pure_live/releases/tag/v3.1.2"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- change the PiliPlus bundle identifier from `com.example.PiliPlus` to `com.example.piliplus`
- derive the app version from the first three components of the release name (`2.1.2.3` → `2.1.2`)
- regenerate the per-app and aggregate AltStore sources

## Why

The latest official PiliPlus IPA (`2.1.2.3`) contains:

- `CFBundleIdentifier`: `com.example.piliplus`
- `CFBundleShortVersionString`: `2.1.2`
- `CFBundleVersion`: `5281`

AltStore/SideStore source metadata must match the downloaded IPA metadata exactly.

## Verification

- inspected `Payload/Runner.app/Info.plist` from the official `PiliPlus_ios_2.1.2+5281.ipa`
- ran `./update.sh PiliPlus`
- ran `git diff --check`
- checked the generated PiliPlus entries in `apps/PiliPlus/apps.json` and `all-apps.json`